### PR TITLE
Update regex crate to support empty sub expressions in alternations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acpplinter"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Tommaso Checchi <tommaso.checchi1@gmail.com>"]
 edition = "2018"
 
@@ -10,7 +10,7 @@ clap = "2.33"
 env_logger = "0.7"
 futures = "0.3"
 log = "0.4"
-regex = "1.3"
+regex = "1.3.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 walkdir = "2.2"


### PR DESCRIPTION
When adding a regex to the mcpe-linter.json an error occurred while using an empty sub expression in a regex alternation. This functionality was added in the rust regex crate version 1.3.8. The default behavior of cargo is to grab the latest compatible version of the crate. In the pipelines we download the pre built linter exe from the Mojang/acpplinter releases github page. In order to reduce the amount of regex expressions in the mcpe linter file we should explicitly update the regex crate to 1.3.8.

More information in [the original PR](https://github.com/Mojang/Minecraftpe/pull/34091#discussion_r712269578) this empty sub expression functionality was used in.